### PR TITLE
Fix advanced settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ This role adds support for these features.
 - Sets the hostname.
 - Adds one or more ssh public keys and/or a password for the default user "ubuntu" so that Ansible can connect to the new machine.
 - Optionally adjusts the hardware, e.g. number of CPUs or memory, see [vmware_guest](https://docs.ansible.com/ansible/latest/modules/vmware_guest_module.html#parameters) for possible customizations.
-- Optionally sets VM notes and/or VM [Configuration Parameters](https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.html.hostclient.doc/GUID-8C639077-FF16-4D5D-9A7A-E16902CE00C2.html).
+- Optionally sets VM notes and/or VM [Configuration Parameters](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.hostclient.doc/GUID-8C639077-FF16-4D5D-9A7A-E16902CE00C2.html).
+- Optionally sets VM [Custom Attributes](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vcenterhost.doc/GUID-73606C4C-763C-4E27-A1DA-032E4C46219D.html)
 - Disk size may be increased (defaults to 10GB), additional disks may be created and added.
 - Optionally changes the dynamic IP address to a static one (taken either from the playbook or from DNS).
 - The VM is turned on and can be used in the same playbook that invoked this role.
@@ -42,7 +43,8 @@ If you want to retrieve the VM's IP addresses from DNS, you also have to
   The FQDN will also be used as the VM name.
 - add A records for each VM you want to create.
 
-The minimum Ansible version is 2.9.0.
+The minimum Ansible version is 2.10.7.
+The minimum community.vmware collection version is 1.8.0, which is part of the Ansible community package 3.2.0.
 
 ### vSphere Permissions
 
@@ -99,6 +101,7 @@ Role Variables
 - VM notes can be set with `annotation`.  
   To use this feature, the VMware permission `Virtual Machine > Configuration > Set annotation` is required.
 - To set VM configuration parameters, supply `advanced_settings` with a list of dicts as shown in the example playbook. 
+- To set VM custom attributes, supply `customvalues` with a list of dicts as show in the example playbook. Note that new custom values will not be created, they should exist in vCenter prior to deploying.
 
 To use a static IP address, use the following keys in the dictionary `static_ip`:
 - `ipv4` - a specific IPv4 address you want to assign. Defaults to the IPv4 address found in DNS for the FQDN.
@@ -132,7 +135,7 @@ playbook:
     - name: Deploy a Ubuntu Cloud Image Virtual Appliance
       hosts: cloudimg
       gather_facts: no
-    
+
       roles:
         - role: hamburger_software.vmware_ubuntu_cloud_image
           vars:
@@ -152,6 +155,9 @@ playbook:
             advanced_settings:
               - key: disk.EnableUUID
                 value: 'TRUE'
+            customvalues:
+              - key: 'yourkey'
+                value: 'yourvalue'
             disk:
               - size_gb: 20
                 datastore: your-datastore

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This role adds support for these features.
 - Sets the hostname.
 - Adds one or more ssh public keys and/or a password for the default user "ubuntu" so that Ansible can connect to the new machine.
 - Optionally adjusts the hardware, e.g. number of CPUs or memory, see [vmware_guest](https://docs.ansible.com/ansible/latest/modules/vmware_guest_module.html#parameters) for possible customizations.
-- Optionally sets VM notes and/or VM [customvalues](https://stackoverflow.com/a/57976458/2402612).
+- Optionally sets VM notes and/or VM [Configuration Parameters](https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.html.hostclient.doc/GUID-8C639077-FF16-4D5D-9A7A-E16902CE00C2.html).
 - Disk size may be increased (defaults to 10GB), additional disks may be created and added.
 - Optionally changes the dynamic IP address to a static one (taken either from the playbook or from DNS).
 - The VM is turned on and can be used in the same playbook that invoked this role.
@@ -98,7 +98,7 @@ Role Variables
 - User defined network mappings can be specified with `networks`, see [vmware_deploy_ovf](https://docs.ansible.com/ansible/latest/modules/vmware_deploy_ovf_module.html#parameters) for semantics.
 - VM notes can be set with `annotation`.  
   To use this feature, the VMware permission `Virtual Machine > Configuration > Set annotation` is required.
-- To set VM [customvalues](https://stackoverflow.com/a/57976458/2402612), supply `customvalues` with a list of dicts as shown in the example playbook. 
+- To set VM configuration parameters, supply `advanced_settings` with a list of dicts as shown in the example playbook. 
 
 To use a static IP address, use the following keys in the dictionary `static_ip`:
 - `ipv4` - a specific IPv4 address you want to assign. Defaults to the IPv4 address found in DNS for the FQDN.
@@ -149,7 +149,7 @@ playbook:
               memory_mb: 2048
             annotation: 'sample VM based on Ubuntu Cloud Image'
             # this avoids excessive syslog messages from multipathd under Ubuntu 20.04
-            customvalues:
+            advanced_settings:
               - key: disk.EnableUUID
                 value: 'TRUE'
             disk:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Creates virtual machines based on Ubuntu Cloud Images in a vSphere environment.
   company: HS - Hamburger Software GmbH & Co. KG
   license: MIT
-  min_ansible_version: 2.9.0
+  min_ansible_version: 2.10.7
   platforms:
     - name: Ubuntu
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,7 @@
     name: "{{ vm_guestname }}"
     annotation: "{{ annotation | default(omit) }}"
     hardware: "{{ hardware | default(omit) }}"
-    customvalues: "{{ customvalues | default(omit) }}"
+    advanced_settings: "{{ advanced_settings | default(omit) }}"
     state: present
   delegate_to: localhost
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,7 @@
     name: "{{ vm_guestname }}"
     annotation: "{{ annotation | default(omit) }}"
     hardware: "{{ hardware | default(omit) }}"
+    customvalues: "{{ customvalues | default(omit) }}"
     advanced_settings: "{{ advanced_settings | default(omit) }}"
     state: present
   delegate_to: localhost


### PR DESCRIPTION
Fixed a thing introduced by a change made to the 'community.vmware' collection where `customsettings` was replaced with `advanced_settings` in a recent release of the collection.

This caused the role to fail with `Unable to find custom value key disk.EnableUUID` 

See [Github Issue #179](https://github.com/ansible-collections/community.vmware/pull/179)
See [vmware_guest_module](https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_module.html)

Tested on whatever version of Ansible is in the very latest AWX Operator build, but there shouldn't be a version dependency change as it's just a string edit in the yaml to match what `community.vmware` is expecting.